### PR TITLE
fix implicit dependency of omniauth-oauth2

### DIFF
--- a/lib/omniauth/strategies/yahoojp.rb
+++ b/lib/omniauth/strategies/yahoojp.rb
@@ -1,4 +1,5 @@
 require 'omniauth-oauth2'
+require 'httpauth'
 
 module OmniAuth
   module Strategies

--- a/omniauth-yahoojp.gemspec
+++ b/omniauth-yahoojp.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'omniauth', '~> 1.0'
   gem.add_dependency 'omniauth-oauth2', '~> 1.1'
+  gem.add_dependency 'httpauth'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
I found mistake of dependency for omaniauth-oauth2 and oauth2.  oauth2-0.9.3 removed dependency of httpauth. so, omniauth-yahoojp isn't works without httpauth.

I added httpauth for omniauth-yahoojp dependency.
