### PR TITLE
Fix doesn't work with oauth2 v1.3.0

### DIFF
--- a/lib/omniauth/strategies/yahoojp.rb
+++ b/lib/omniauth/strategies/yahoojp.rb
@@ -9,7 +9,8 @@ module OmniAuth
       option :client_options, {
         :site => 'https://auth.login.yahoo.co.jp',
         :authorize_url => '/yconnect/v1/authorization',
-        :token_url => '/yconnect/v1/token'
+        :token_url => '/yconnect/v1/token',
+        :auth_scheme => :basic_auth
       }
 
       option :authorize_options, [:display, :prompt, :scope]
@@ -17,7 +18,7 @@ module OmniAuth
       def request_phase
         super
       end
-      
+
       uid { raw_info['user_id'] }
 
       info do


### PR DESCRIPTION
- refs https://github.com/intridea/oauth2/blob/master/CHANGELOG.md#130---2016-12-28
- omniauth-yahoojp doesn't work with :request_body
- set :basic_auth to client_options