### PR TITLE
Use POST to request to UserInfo API

### DIFF
--- a/lib/omniauth/strategies/yahoojp.rb
+++ b/lib/omniauth/strategies/yahoojp.rb
@@ -51,7 +51,7 @@ module OmniAuth
 
       def raw_info
         access_token.options[:mode] = :header
-        @raw_info ||= access_token.get('https://userinfo.yahooapis.jp/yconnect/v2/attribute').parsed
+        @raw_info ||= access_token.post('https://userinfo.yahooapis.jp/yconnect/v2/attribute').parsed
       end
 
       def prune!(hash)


### PR DESCRIPTION
According to the following release, after May 2021, UserInfo API will only accept POST requests.
https://developer.yahoo.co.jp/changelog/2021-02-03-yconnect.html

Also, it is already stated in the official documentation now that the UserInfo API accepts POST requests.
https://developer.yahoo.co.jp/yconnect/v2/userinfo.html

Confirmed that I can call the UserInfo API with a POST request

```
curl -X POST \
-s \
--url https://userinfo.yahooapis.jp/yconnect/v2/attribute \
-H 'Authorization: Bearer [FILTERED]' \
--data '' | jq
{
  "sub": "FILTERED",
  "name": "FILTERED",
  "given_name": "FILTERED",
  "given_name#ja-Kana-JP": "FILTERED",
  "given_name#ja-Hani-JP": "FILTERED",
  "family_name": "FILTERED",
  "family_name#ja-Kana-JP": "FILTERED",
  "family_name#ja-Hani-JP": "FILTERED",
  "gender": "male",
  "locale": "ja-JP",
  "email": "FILTERED",
  "email_verified": true,
  "birthdate": "FILTERED",
  "zoneinfo": "Asia/Tokyo",
  "nickname": "nhosoya",
  "picture": "FILTERED"
}
```
