### PR TITLE
Add Downstream Test Project reference to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,9 @@ This is a Ruby gem that implements an OmniAuth strategy for Yahoo! JAPAN's YConn
 ### Dependencies
 - `omniauth` and `omniauth-oauth2` for OAuth framework
 - `httpauth` for HTTP basic authentication headers
+
+## Downstream Test Project
+
+- [`omniauth-yahoojp-tester-rails5`](https://github.com/mikanmarusan/omniauth-yahoojp-tester-rails5) is a Rails 5 app that consumes this gem for integration testing.
+- Its CLAUDE.md documents the exact API surface used and cross-project update rules.
+- Use `/add-dir ../omniauth-yahoojp-tester-rails5` to add it for cross-project awareness when making API changes.


### PR DESCRIPTION
## Summary

- Add a `Downstream Test Project` section to CLAUDE.md pointing to `omniauth-yahoojp-tester-rails5`
- Includes GitHub URL as fallback and `/add-dir` instruction for cross-project awareness
- Kept minimal (pointer only) since the tester's CLAUDE.md already documents the detailed API surface and cross-project update rules

## Test plan

- [x] Verified CLAUDE.md reads correctly with the new section appended
- [x] Confirmed symmetry with the tester project's `Upstream Gem Dependency` section