### PR TITLE
Add id_token support and optional userinfo_access (v1.0.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in omniauth-yahoojp.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **These notes are based on master, please see tags for README pertaining to specific releases.**
 
-This is the official OmniAuth strategy for authenticating to Yahoo! JAPAN( [YConnect](http://developer.yahoo.co.jp/yconnect/v2/) ).
+This is the OmniAuth strategy for authenticating to Yahoo! JAPAN( [YConnect](http://developer.yahoo.co.jp/yconnect/v2/) ).
 To use it, you'll need to sign up for a YConnect Client ID and Secret
 on the [Yahoo! JAPAN Developer Network](https://e.developer.yahoo.co.jp/dashboard/).
 
@@ -22,13 +22,14 @@ Then `bundle install`.
 
 `OmniAuth::Strategies::YahooJp` is simply a Rack middleware. Read the OmniAuth docs for detailed instructions: https://github.com/intridea/omniauth.
 
-YConnect API v2 lets you set scopes to provide granular access to different types of data: 
+YConnect API v2 lets you set scopes to provide granular access to different types of data:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-    provider :yahoojp, ENV['YAHOOJP_KEY'], ENV['YAHOOJP_SECRET'], 
+    provider :yahoojp, ENV['YAHOOJP_KEY'], ENV['YAHOOJP_SECRET'],
     {
-        scope: "openid profile email address"
+        scope: "openid profile email address",
+        userinfo_access: true  # default: true
     }
 end
 ```
@@ -50,6 +51,24 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
+### `userinfo_access` Option
+
+Controls how user profile information is retrieved.
+
+- `userinfo_access: true` (default) — Calls the UserInfo API (`https://userinfo.yahooapis.jp/yconnect/v2/attribute`) to retrieve full profile information including name variants (kana, kanji), gender, locale, birthdate, nickname, picture, email, and address.
+- `userinfo_access: false` — Skips the UserInfo API call and extracts profile information from the `id_token` claims instead. This is useful when your application does not have access to the UserInfo API.
+
+> **Note:** The fields available in `id_token` claims may differ from those returned by the UserInfo API. The `id_token` typically contains a subset of profile fields depending on the requested scopes. Yahoo! JAPAN has made the UserInfo API access-restricted, so some applications may need to rely on `id_token` claims.
+
+### ID Token
+
+When the `openid` scope is requested, the strategy automatically captures the `id_token` returned by Yahoo! JAPAN's token endpoint.
+
+- `credentials.id_token` — The raw JWT string as returned from the token endpoint.
+- `extra.id_token_claims` — The decoded claims hash from the `id_token`.
+
+The `id_token` signature verification is skipped because the token is received directly from Yahoo! JAPAN's token endpoint over TLS in the Authorization Code Flow, which guarantees its authenticity.
+
 ### API Version
 
 OmniAuth YahooJp uses versioned API endpoints by default (current v2). You can configure a different version via `client_options` hash passed to `provider`, specifically you should change the version in the `site` and `authorize_url` parameters. For example, to change to v1:
@@ -66,6 +85,52 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     }
 end
 ```
+
+## Auth Hash
+
+Here is an example of the auth hash available in `request.env['omniauth.auth']`:
+
+```ruby
+{
+  provider: "yahoojp",
+  uid: "abcdefg",
+  info: {
+    sub: "abcdefg",
+    name: "山田 太郎",
+    given_name: "太郎",
+    given_name_ja_kana_jp: "タロウ",
+    given_name_ja_hani_jp: "太郎",
+    family_name: "山田",
+    family_name_ja_kana_jp: "ヤマダ",
+    family_name_ja_hani_jp: "山田",
+    gender: "male",
+    locale: "ja-JP",
+    email: "example@yahoo.co.jp",
+    email_verified: true
+  },
+  credentials: {
+    token: "ACCESS_TOKEN",
+    refresh_token: "REFRESH_TOKEN",
+    expires_at: 1496120719,
+    expires: true,
+    id_token: "eyJhbGciOiJSUzI1NiIs..."
+  },
+  extra: {
+    raw_info: { ... },           # Full response from UserInfo API (or id_token claims)
+    id_token: "eyJhbGciOiJSUzI1NiIs...",  # Raw JWT string
+    id_token_claims: {           # Decoded id_token claims
+      iss: "https://auth.login.yahoo.co.jp/yconnect/v2",
+      sub: "abcdefg",
+      aud: ["YOUR_CLIENT_ID"],
+      exp: 1496120719,
+      iat: 1496117119,
+      nonce: "..."
+    }
+  }
+}
+```
+
+> **Note:** Available fields in `info` and `extra.raw_info` depend on the requested scopes and the `userinfo_access` setting.
 
 ## License
 

--- a/lib/omniauth-yahoojp/version.rb
+++ b/lib/omniauth-yahoojp/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module YahooJp
-    VERSION = "0.2.1"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/omniauth/strategies/yahoojp.rb
+++ b/lib/omniauth/strategies/yahoojp.rb
@@ -1,5 +1,6 @@
 require 'omniauth-oauth2'
 require 'httpauth'
+require 'json/jwt'
 
 module OmniAuth
   module Strategies
@@ -14,10 +15,7 @@ module OmniAuth
       }
 
       option :authorize_options, [:display, :prompt, :scope, :bail]
-
-      def request_phase
-        super
-      end
+      option :userinfo_access, true
 
       uid { raw_info['sub'] }
 
@@ -39,19 +37,47 @@ module OmniAuth
           :picture    => raw_info['picture'],
           :email      => raw_info['email'],
           :email_verified => raw_info['email_verified'],
-          :address    => raw_info['address'], 
+          :address    => raw_info['address'],
         })
       end
 
       extra do
         hash = {}
         hash[:raw_info] = raw_info unless skip_info?
+        hash[:id_token] = id_token if id_token
+        hash[:id_token_claims] = id_token_claims if id_token
         prune! hash
       end
 
+      credentials do
+        hash = {'token' => access_token.token}
+        hash['refresh_token'] = access_token.refresh_token if access_token.refresh_token
+        hash['expires_at'] = access_token.expires_at if access_token.expires?
+        hash['expires'] = access_token.expires?
+        hash['id_token'] = id_token if id_token
+        hash
+      end
+
       def raw_info
-        access_token.options[:mode] = :header
-        @raw_info ||= access_token.get('https://userinfo.yahooapis.jp/yconnect/v2/attribute').parsed
+        @raw_info ||= if options.userinfo_access
+          access_token.options[:mode] = :header
+          access_token.get('https://userinfo.yahooapis.jp/yconnect/v2/attribute').parsed
+        elsif id_token
+          id_token_claims
+        else
+          {}
+        end
+      end
+
+      def id_token
+        @id_token ||= access_token&.params&.dig('id_token').presence
+      end
+
+      def id_token_claims
+        return nil unless id_token
+        # Signature verification is skipped because the id_token was received
+        # directly from Yahoo's token endpoint over TLS (Authorization Code Flow).
+        @id_token_claims ||= JSON::JWT.decode(id_token, :skip_verification)
       end
 
       def prune!(hash)
@@ -69,7 +95,7 @@ module OmniAuth
           :headers => {'Authorization' => HTTPAuth::Basic.pack_authorization(client.id, client.secret)}
         }
 
-        client.get_token(token_params);
+        client.get_token(token_params)
       end
 
       def callback_url

--- a/omniauth-yahoojp.gemspec
+++ b/omniauth-yahoojp.gemspec
@@ -4,8 +4,8 @@ require File.expand_path('../lib/omniauth-yahoojp/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["mikanmarusan"]
   gem.email         = ["chiakifujimon@gmail.com"]
-  gem.description   = %q{Official OmniAuth strategy for Yahoo! JAPAN.}
-  gem.summary       = %q{Official OmniAuth strategy for Yahoo! JAPAN.}
+  gem.description   = %q{OmniAuth strategy for Yahoo! JAPAN.}
+  gem.summary       = %q{OmniAuth strategy for Yahoo! JAPAN.}
   gem.homepage      = "https://github.com/mikanmarusan/omniauth-yahoojp"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
@@ -14,12 +14,13 @@ Gem::Specification.new do |gem|
   gem.name          = "omniauth-yahoojp"
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::YahooJp::VERSION
-  gem.licenses      = "MIT"
+  gem.licenses      = ["MIT"]
 
   gem.add_dependency 'omniauth', '>= 1.0'
   gem.add_dependency 'omniauth-oauth2', '>= 1.1'
   gem.add_dependency 'httpauth'
-  gem.add_development_dependency 'rspec', '~> 2.7'
+  gem.add_dependency 'json-jwt', '>= 1.16.6'
+  gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'webmock'

--- a/spec/omniauth/strategies/yahoojp_spec.rb
+++ b/spec/omniauth/strategies/yahoojp_spec.rb
@@ -1,23 +1,289 @@
 require 'spec_helper'
 require 'omniauth-yahoojp'
+require 'json/jwt'
 
-describe OmniAuth::Strategies::YahooJp do
+RSpec.describe OmniAuth::Strategies::YahooJp do
+  let(:app) { lambda { |_env| [200, {}, ['Hello']] } }
+  let(:strategy) { described_class.new(app, 'client_id', 'client_secret') }
 
-  subject do
-    OmniAuth::Strategies::YahooJp.new({})
+  describe 'client options' do
+    it 'has correct site' do
+      expect(strategy.options.client_options.site).to eq('https://auth.login.yahoo.co.jp')
+    end
+
+    it 'has correct authorize url' do
+      expect(strategy.options.client_options.authorize_url).to eq('/yconnect/v2/authorization')
+    end
+
+    it 'has correct token url' do
+      expect(strategy.options.client_options.token_url).to eq('/yconnect/v2/token')
+    end
   end
 
-  context "client options" do
-    it 'should have correct site' do
-      subject.options.client_options.site.should eq("https://auth.login.yahoo.co.jp")
+  describe 'default options' do
+    it 'has userinfo_access enabled by default' do
+      expect(strategy.options.userinfo_access).to be true
+    end
+  end
+
+  context 'with access_token' do
+    let(:jwt_payload) { { 'sub' => 'test123', 'name' => 'Test User', 'email' => 'test@example.com' } }
+    let(:jwt_string) { JSON::JWT.new(jwt_payload).to_s }
+    let(:access_token) do
+      instance_double(
+        OAuth2::AccessToken,
+        token: 'mock_token',
+        refresh_token: 'mock_refresh',
+        expires?: true,
+        expires_at: 1234567890,
+        params: { 'id_token' => jwt_string },
+        options: {}
+      )
     end
 
-    it 'should have correct authorize url' do
-      subject.options.client_options.authorize_url.should eq('/yconnect/v1/authorization')
+    before do
+      allow(strategy).to receive(:access_token).and_return(access_token)
     end
 
-    it 'should have correct token url' do
-      subject.options.client_options.token_url.should eq('/yconnect/v1/token')
+    describe '#id_token' do
+      it 'returns the id_token from access_token params' do
+        expect(strategy.id_token).to eq(jwt_string)
+      end
+
+      it 'returns nil when no id_token in params' do
+        allow(access_token).to receive(:params).and_return({})
+        expect(strategy.id_token).to be_nil
+      end
+
+      it 'returns nil when id_token is empty string' do
+        allow(access_token).to receive(:params).and_return({ 'id_token' => '' })
+        expect(strategy.id_token).to be_nil
+      end
+    end
+
+    describe '#id_token_claims' do
+      it 'decodes the JWT without verification' do
+        claims = strategy.id_token_claims
+        expect(claims['sub']).to eq('test123')
+        expect(claims['name']).to eq('Test User')
+        expect(claims['email']).to eq('test@example.com')
+      end
+
+      it 'memoizes the result' do
+        first_call = strategy.id_token_claims
+        second_call = strategy.id_token_claims
+        expect(first_call).to equal(second_call)
+      end
+
+      it 'returns nil when id_token is nil' do
+        allow(access_token).to receive(:params).and_return({})
+        expect(strategy.id_token_claims).to be_nil
+      end
+
+      it 'raises on malformed id_token' do
+        allow(access_token).to receive(:params).and_return({ 'id_token' => 'not-a-jwt' })
+        expect { strategy.id_token_claims }.to raise_error(JSON::JWT::InvalidFormat)
+      end
+    end
+
+    describe '#raw_info' do
+      context 'with userinfo_access: true' do
+        let(:userinfo_response) do
+          instance_double(OAuth2::Response, parsed: {
+            'sub' => 'user456',
+            'name' => 'Yahoo User',
+            'email' => 'yahoo@example.com',
+            'address' => { 'country' => 'JP' }
+          })
+        end
+
+        before do
+          allow(access_token).to receive(:get)
+            .with('https://userinfo.yahooapis.jp/yconnect/v2/attribute')
+            .and_return(userinfo_response)
+        end
+
+        it 'calls the UserInfo API' do
+          strategy.raw_info
+          expect(access_token).to have_received(:get)
+            .with('https://userinfo.yahooapis.jp/yconnect/v2/attribute')
+        end
+
+        it 'sets access_token mode to header' do
+          strategy.raw_info
+          expect(access_token.options[:mode]).to eq(:header)
+        end
+
+        it 'returns parsed UserInfo response' do
+          expect(strategy.raw_info['sub']).to eq('user456')
+          expect(strategy.raw_info['name']).to eq('Yahoo User')
+        end
+      end
+
+      context 'with userinfo_access: false and id_token present' do
+        before do
+          strategy.options[:userinfo_access] = false
+        end
+
+        it 'returns id_token_claims' do
+          expect(strategy.raw_info['sub']).to eq('test123')
+          expect(strategy.raw_info['name']).to eq('Test User')
+        end
+
+        it 'does not call the UserInfo API' do
+          expect(access_token).not_to receive(:get)
+          strategy.raw_info
+        end
+      end
+
+      context 'with userinfo_access: false and no id_token' do
+        before do
+          strategy.options[:userinfo_access] = false
+          allow(access_token).to receive(:params).and_return({})
+        end
+
+        it 'returns empty hash' do
+          expect(strategy.raw_info).to eq({})
+        end
+      end
+    end
+
+    describe '#info' do
+      let(:full_profile) do
+        {
+          'sub' => 'user456',
+          'name' => 'Yahoo User',
+          'given_name' => 'Taro',
+          'given_name#ja-Kana-JP' => 'タロウ',
+          'given_name#ja-Hani-JP' => '太郎',
+          'family_name' => 'Yamada',
+          'family_name#ja-Kana-JP' => 'ヤマダ',
+          'family_name#ja-Hani-JP' => '山田',
+          'gender' => 'male',
+          'zoneinfo' => 'Asia/Tokyo',
+          'locale' => 'ja-JP',
+          'birthdate' => '1990-01-01',
+          'nickname' => 'taro',
+          'picture' => 'https://example.com/photo.jpg',
+          'email' => 'taro@example.com',
+          'email_verified' => true,
+          'address' => { 'country' => 'JP', 'region' => 'Tokyo' }
+        }
+      end
+      let(:userinfo_response) do
+        instance_double(OAuth2::Response, parsed: full_profile)
+      end
+
+      before do
+        allow(access_token).to receive(:get)
+          .with('https://userinfo.yahooapis.jp/yconnect/v2/attribute')
+          .and_return(userinfo_response)
+      end
+
+      it 'maps all standard fields' do
+        info = strategy.info
+        expect(info[:sub]).to eq('user456')
+        expect(info[:name]).to eq('Yahoo User')
+        expect(info[:given_name]).to eq('Taro')
+        expect(info[:family_name]).to eq('Yamada')
+        expect(info[:email]).to eq('taro@example.com')
+        expect(info[:nickname]).to eq('taro')
+        expect(info[:picture]).to eq('https://example.com/photo.jpg')
+      end
+
+      it 'maps Japanese locale-specific fields' do
+        info = strategy.info
+        expect(info[:given_name_ja_kana_jp]).to eq('タロウ')
+        expect(info[:given_name_ja_hani_jp]).to eq('太郎')
+        expect(info[:family_name_ja_kana_jp]).to eq('ヤマダ')
+        expect(info[:family_name_ja_hani_jp]).to eq('山田')
+      end
+
+      it 'maps address as nested hash' do
+        info = strategy.info
+        expect(info[:address]['country']).to eq('JP')
+      end
+
+      it 'prunes nil values' do
+        allow(userinfo_response).to receive(:parsed).and_return({ 'sub' => 'user456' })
+        info = strategy.info
+        expect(info).not_to have_key(:name)
+        expect(info).not_to have_key(:email)
+      end
+    end
+
+    describe '#uid' do
+      context 'with userinfo_access: true' do
+        let(:userinfo_response) do
+          instance_double(OAuth2::Response, parsed: { 'sub' => 'user456' })
+        end
+
+        before do
+          allow(access_token).to receive(:get)
+            .with('https://userinfo.yahooapis.jp/yconnect/v2/attribute')
+            .and_return(userinfo_response)
+        end
+
+        it 'returns sub from UserInfo' do
+          expect(strategy.uid).to eq('user456')
+        end
+      end
+
+      context 'with userinfo_access: false' do
+        before do
+          strategy.options[:userinfo_access] = false
+        end
+
+        it 'returns sub from id_token' do
+          expect(strategy.uid).to eq('test123')
+        end
+      end
+    end
+
+    describe '#credentials' do
+      it 'includes token' do
+        expect(strategy.credentials['token']).to eq('mock_token')
+      end
+
+      it 'includes refresh_token' do
+        expect(strategy.credentials['refresh_token']).to eq('mock_refresh')
+      end
+
+      it 'includes expires_at' do
+        expect(strategy.credentials['expires_at']).to eq(1234567890)
+      end
+
+      it 'includes expires flag' do
+        expect(strategy.credentials['expires']).to be true
+      end
+
+      it 'includes id_token' do
+        expect(strategy.credentials['id_token']).to eq(jwt_string)
+      end
+
+      it 'omits id_token when not present' do
+        allow(access_token).to receive(:params).and_return({})
+        expect(strategy.credentials).not_to have_key('id_token')
+      end
+    end
+
+    describe '#extra' do
+      before do
+        strategy.options[:userinfo_access] = false
+      end
+
+      it 'includes id_token' do
+        expect(strategy.extra[:id_token]).to eq(jwt_string)
+      end
+
+      it 'includes id_token_claims' do
+        claims = strategy.extra[:id_token_claims]
+        expect(claims['sub']).to eq('test123')
+      end
+
+      it 'includes raw_info' do
+        expect(strategy.extra[:raw_info]).not_to be_nil
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,4 @@ require 'omniauth-yahoojp'
 RSpec.configure do |config|
   config.include WebMock::API
   config.include Rack::Test::Methods
-  config.extend  OmniAuth::Test::StrategyMacros, :type => :strategy
 end
-


### PR DESCRIPTION
## Summary

- **`userinfo_access` option**: New option (default: `true`) to control how user profile data is retrieved. When `false`, profile data is extracted from `id_token` claims instead of calling the UserInfo API. This supports applications that don't have access to Yahoo! JAPAN's UserInfo API.
- **`id_token` support**: Automatically captures and decodes the `id_token` JWT from the token endpoint. Exposes `credentials.id_token` (raw JWT) and `extra.id_token_claims` (decoded claims hash).
- **Version bump to 1.0.0**: Adds `json-jwt` dependency, upgrades RSpec to 3.x, and rewrites test suite with comprehensive coverage.
- **README updates**: Documents `userinfo_access` option, ID Token behavior, and full auth hash structure.

## Changes

| File | Description |
|------|-------------|
| `lib/omniauth/strategies/yahoojp.rb` | Add `userinfo_access` option, `id_token`/`id_token_claims` methods, custom `credentials` block |
| `lib/omniauth-yahoojp/version.rb` | Bump to 1.0.0 |
| `omniauth-yahoojp.gemspec` | Add `json-jwt` dependency, upgrade rspec to ~> 3.0 |
| `Gemfile` | Use HTTPS for rubygems source |
| `spec/omniauth/strategies/yahoojp_spec.rb` | Full rewrite with RSpec 3 syntax and comprehensive tests |
| `spec/spec_helper.rb` | Remove deprecated OmniAuth test macros |
| `README.md` | Add userinfo_access, id_token, and auth hash documentation |

## Test plan

- [ ] `rake spec` passes all tests
- [ ] Verify with downstream tester app (`omniauth-yahoojp-tester-rails5`)
- [ ] Test `userinfo_access: true` flow (UserInfo API call)
- [ ] Test `userinfo_access: false` flow (id_token claims fallback)