### PR TITLE
Update downstream test project repo name in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,6 @@ This is a Ruby gem that implements an OmniAuth strategy for Yahoo! JAPAN's YConn
 
 ## Downstream Test Project
 
-- [`omniauth-yahoojp-tester-rails5`](https://github.com/mikanmarusan/omniauth-yahoojp-tester-rails5) is a Rails 5 app that consumes this gem for integration testing.
+- [`omniauth-yahoojp-tester-containers`](https://github.com/mikanmarusan/omniauth-yahoojp-tester-containers) is an app that consumes this gem for integration testing.
 - Its CLAUDE.md documents the exact API surface used and cross-project update rules.
-- Use `/add-dir ../omniauth-yahoojp-tester-rails5` to add it for cross-project awareness when making API changes.
+- Use `/add-dir ../omniauth-yahoojp-tester-containers` to add it for cross-project awareness when making API changes.


### PR DESCRIPTION
## Summary
- Updated all 4 references in the Downstream Test Project section of CLAUDE.md from `omniauth-yahoojp-tester-rails5` to `omniauth-yahoojp-tester-containers`
- Updated description from "is a Rails 5 app" to "is an app" to reflect the project's current nature
- Fixed missing trailing newline

Closes #20

## Test plan
- [x] Verified the target repository `mikanmarusan/omniauth-yahoojp-tester-containers` exists on GitHub
- [x] Confirmed all 4 references (link text, URL, description, `/add-dir` path) are updated consistently