### PR TITLE
test: verify Claude Code Review no longer triggers (cleanup pending)

### DIFF
--- a/.workflow-removal-test-marker
+++ b/.workflow-removal-test-marker
@@ -1,0 +1,3 @@
+Temporary marker file for issue #22 verification — confirms that opening a PR
+no longer triggers Claude Code Review. This branch and file will be deleted
+after the verification is complete.


### PR DESCRIPTION
Throwaway PR to confirm that opening a PR no longer fires the
`Claude Code Review` workflow after #23. Will be closed and the branch deleted
once verification completes. Do not merge.