### PR TITLE
fix(yahoojp): rescue malformed id_token JWT in id_token_claims

### DIFF
--- a/lib/omniauth/strategies/yahoojp.rb
+++ b/lib/omniauth/strategies/yahoojp.rb
@@ -67,7 +67,7 @@ module OmniAuth
           access_token.options[:mode] = :header
           access_token.get('https://userinfo.yahooapis.jp/yconnect/v2/attribute').parsed
         elsif id_token
-          id_token_claims
+          id_token_claims || {}
         else
           {}
         end
@@ -80,6 +80,8 @@ module OmniAuth
       def id_token_claims
         return nil unless id_token
         @id_token_claims ||= verify_id_token!
+      rescue JSON::JWT::InvalidFormat
+        nil
       end
 
       def prune!(hash)

--- a/spec/omniauth/strategies/yahoojp_spec.rb
+++ b/spec/omniauth/strategies/yahoojp_spec.rb
@@ -118,9 +118,9 @@ RSpec.describe OmniAuth::Strategies::YahooJp do
         expect(WebMock).not_to have_requested(:get, 'https://auth.login.yahoo.co.jp/yconnect/v2/jwks')
       end
 
-      it 'raises on malformed id_token' do
+      it 'returns nil on malformed id_token' do
         allow(access_token).to receive(:params).and_return({ 'id_token' => 'not-a-jwt' })
-        expect { strategy.id_token_claims }.to raise_error(JSON::JWT::InvalidFormat)
+        expect(strategy.id_token_claims).to be_nil
       end
 
       context 'with invalid signature' do
@@ -324,6 +324,17 @@ RSpec.describe OmniAuth::Strategies::YahooJp do
         end
 
         it 'returns empty hash' do
+          expect(strategy.raw_info).to eq({})
+        end
+      end
+
+      context 'with userinfo_access: false and malformed id_token' do
+        before do
+          strategy.options[:userinfo_access] = false
+          allow(access_token).to receive(:params).and_return({ 'id_token' => 'not-a-jwt' })
+        end
+
+        it 'returns an empty hash instead of raising' do
           expect(strategy.raw_info).to eq({})
         end
       end


### PR DESCRIPTION
## Summary

Resolves #17. A malformed `id_token` (a structurally invalid JWT) caused
`id_token_claims` to raise `JSON::JWT::InvalidFormat`, crashing the entire
OmniAuth callback. This change rescues that one exception and returns `nil`
so the auth flow degrades gracefully, while keeping all security-validation
failures hard.

## Changes

- **`id_token_claims`**: rescue `JSON::JWT::InvalidFormat` only, return `nil`.
  Signature failures (`JSON::JWS::VerificationFailed`) and issuer/audience/
  expiry failures (`IdTokenValidationError`) keep raising — verified that
  `InvalidFormat` and `VerificationFailed` are sibling classes, so the rescue
  cannot swallow signature failures.
- **`raw_info`**: guard the `id_token` branch with `|| {}` so that a `nil`
  claims result under `userinfo_access: false` degrades to `{}` instead of
  relocating the crash to `uid`/`info` as a `NoMethodError`.

## Tests

- Inverted the existing "raises on malformed id_token" spec to expect `nil`.
- Added a regression test: `userinfo_access: false` + malformed token →
  `raw_info == {}` (no raise).
- All existing signature/issuer/audience/expiry raise tests stay unchanged
  and act as a guard against the rescue ever broadening.

`bundle exec rspec` → 44 examples, 0 failures.

Closes #17