### PR TITLE
chore(release): bump version to 1.0.2

### DIFF
--- a/lib/omniauth-yahoojp/version.rb
+++ b/lib/omniauth-yahoojp/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module YahooJp
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end


### PR DESCRIPTION
## Summary

Bump the gem version from 1.0.1 to 1.0.2 to release the malformed
`id_token` rescue fix merged in #26 (Closes #17).

## Changes

- `lib/omniauth-yahoojp/version.rb`: `1.0.1` → `1.0.2`